### PR TITLE
convertStringToHash

### DIFF
--- a/src/Thumbhash.php
+++ b/src/Thumbhash.php
@@ -140,6 +140,10 @@ class Thumbhash
         return rtrim(base64_encode(implode(array_map("chr", $hash))), '=');
     }
 
+    public static function convertStringToHash(string $str): array
+    {
+        return array_map("ord", str_split(base64_decode($str . "=")));
+    }
 
     /**
      * Decodes a ThumbHash to an RGBA image. RGB is not premultiplied by A.


### PR DESCRIPTION
Hi,

I compared my implementation (https://github.com/evanw/thumbhash/pull/8) with yours and couldn't find any obvious problems. Yours seems cleaner and more like a complete package, so I'm discarding my implementation.

I added a function `convertStringToHash` that complements your `convertHashToString`.

Just two suggestions:

1.  function `encode` should be renamed to something like `RGBAToHash` to keep it similar to the complementary function name `hashToRGBA`.
2. The lib requires php 8 because of multiple return types in the following line: https://github.com/SRWieZ/thumbhash/blob/0cfc7043967530b5a7e9289f46d661261e7a9158/src/Thumbhash.php#L281
I know that php 8.1 ist the current actively supported version and 7 is end of life, but a lot of real world projects still rely on older versions.

Thanks for your work on this!