### PR TITLE
fix: throw an Exception when GD can't decode the image data

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -4,9 +4,23 @@ namespace Thumbhash;
 
 use Imagick;
 
+/**
+ * Extract image data using the GD extension.
+ *
+ * GD only provides 127-bit alpha data, so this up-scales it to 255 bits.
+ *
+ * @param  string  $content  The binary data of the image to be processed.
+ * @return array An array containing the width, height, and pixel data of the image.
+ * @throws Exception
+ */
 function extract_size_and_pixels_with_gd($content): array
 {
     $image = imagecreatefromstring($content);
+
+    if ($image === false) {
+        throw new \Exception("Unable to read data, make sure that the appropriate " .
+                             "image type support is enabled in GD.");
+    }
 
     $width = imagesx($image);
     $height = imagesy($image);

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -11,7 +11,7 @@ use Imagick;
  *
  * @param  string  $content  The binary data of the image to be processed.
  * @return array An array containing the width, height, and pixel data of the image.
- * @throws Exception
+ * @throws \Exception
  */
 function extract_size_and_pixels_with_gd($content): array
 {
@@ -19,7 +19,7 @@ function extract_size_and_pixels_with_gd($content): array
 
     if ($image === false) {
         throw new \Exception("Unable to read data, make sure that the appropriate " .
-                             "image type support is enabled in GD.");
+            "image type support is enabled in GD.");
     }
 
     $width = imagesx($image);

--- a/tests/Unit/UnitTest.php
+++ b/tests/Unit/UnitTest.php
@@ -1,5 +1,21 @@
 <?php
 
+use Thumbhash\Thumbhash;
+use function Thumbhash\extract_size_and_pixels_with_gd;
+use function Thumbhash\extract_size_and_pixels_with_imagick;
+
 it('throws exception if pixel width or height > 100 ', function () {
-    \Thumbhash\Thumbhash::RGBAToHash(101, 100, []);
+    Thumbhash::RGBAToHash(101, 100, []);
+})->throws(Exception::class);
+
+it('throws exception if gd cannot decode the image data', function () {
+    extract_size_and_pixels_with_gd('not an image');
+})->throws(Exception::class);
+
+it('throws exception if imagick cannot decode the image data', function () {
+    extract_size_and_pixels_with_imagick('not an image');
+})->throws(Exception::class);
+
+it('throws exception if imagick pixel iterator cannot decode the image data', function () {
+    \Thumbhash\extract_size_and_pixels_with_imagick_pixel_iterator('not an image');
 })->throws(Exception::class);


### PR DESCRIPTION
This throws a more descriptive exception when GD fails to decode the image, which is likely to be because GD doesn't have support for that image type. Before, it would just fail on the subsequent call to imagesx().