### PR TITLE
 Add `toAverageColor` method to extract average color from a ThumbHash

### DIFF
--- a/src/Thumbhash.php
+++ b/src/Thumbhash.php
@@ -275,6 +275,26 @@ class Thumbhash
         ];
     }
 
+    /**
+     * Converts a ThumbHash to a color hex string (e.g. '#fff0f0f0').
+     *
+     * @param  array  $hash  The bytes of the ThumbHash.
+     * @return string The hex color string in the format '#AARRGGBB'.
+     */
+    function toAverageColor(array $hash): string
+    {
+        $rgba = $this->toAverageRGBA($hash);
+
+        // Convert from 0–1 float to 0–255 int
+        $a = (int) round($rgba['a'] * 255);
+        $r = (int) round($rgba['r'] * 255);
+        $g = (int) round($rgba['g'] * 255);
+        $b = (int) round($rgba['b'] * 255);
+
+        // Format as a hex color string: #AARRGGBB
+        return sprintf('#%02X%02X%02X%02X', $a, $r, $g, $b);
+    }
+
 
     /**
      * Extracts the approximate aspect ratio of the original image.

--- a/tests/Datasets/ImagesAverageColor.php
+++ b/tests/Datasets/ImagesAverageColor.php
@@ -1,0 +1,41 @@
+<?php
+dataset('images_average_color', [
+    [
+        'url'  => 'assets/sunrise.jpg',
+        'average_color' => '#FF565258',
+    ],
+    [
+        'url'  => 'assets/sunset.jpg',
+        'average_color' => '#FF6E7274',
+    ],
+    [
+        'url'  => 'assets/field.jpg',
+        'average_color' => '#FF6A7674',
+    ],
+    [
+        'url'  => 'assets/fall.jpg',
+        'average_color' => '#FF847759',
+    ],
+    [
+        'url'  => 'assets/street.jpg',
+        'average_color' => '#FF5F5B51',
+    ],
+    [
+        'url'  => 'assets/mountain.jpg',
+        'average_color' => '#FF626668',
+    ],
+    [
+        'url'  => 'assets/coast.jpg',
+        'average_color' => '#FF898583',
+    ],
+
+    // Images with transparency
+    [
+        'url'  => 'assets/firefox.png',
+        'average_color' => '#BBC2754E',
+    ],
+    [
+        'url'  => 'assets/opera.png',
+        'average_color' => '#77E51E2D',
+    ],
+]);

--- a/tests/Feature/ThumbhashTest.php
+++ b/tests/Feature/ThumbhashTest.php
@@ -15,3 +15,16 @@ test('it returns the correct hash', function ($url, $hash) {
     expect($encodedBase64)->toBe($hash);
 })
 ->with('images');
+
+test('it returns the correct average color', function ($url, $average_color) {
+
+    $content = file_get_contents($url);
+
+    list($width, $height, $pixels) = extract_size_and_pixels_with_imagick($content);
+
+    $encoded = Thumbhash::RGBAToHash($width, $height, $pixels);
+
+    $averageColor = (new Thumbhash)->toAverageColor($encoded);
+
+    expect($averageColor)->toBe($average_color);
+})->with('images_average_color');


### PR DESCRIPTION
#### **Summary**
This Pull Request introduces the `toAverageColor` method to the `Thumbhash` class. The method calculates the average color from a given ThumbHash and returns the result as a hexadecimal color string in the format `#AARRGGBB`.